### PR TITLE
New Json serialization model

### DIFF
--- a/src/typegen.zig
+++ b/src/typegen.zig
@@ -556,7 +556,7 @@ const TypeGenerator = struct {
         var res: ArrayList(u8) = .empty;
 
         // Special case for Optional(T)
-        if (isOptional(T)) {
+        if (comptime isOptional(T)) {
             const parsed_res = try self.extractIdentifier(@FieldType(T, "value"));
             try res.appendSlice(self.arena_alloc, parsed_res.parsed);
             return res.toOwnedSlice(self.arena_alloc);

--- a/src/typegen.zig
+++ b/src/typegen.zig
@@ -193,7 +193,7 @@ const TypeGenerator = struct {
 
         // Second pass: Generate typings for all top-level types across all endpoint files
         inline for (endpoints) |endpoint| {
-            _, const EndpointType = endpoint;
+            const endpoint_path, const EndpointType = endpoint;
             const type_info = @typeInfo(EndpointType);
             inline for (type_info.@"struct".decls) |decl| {
                 const decl_info = @typeInfo(@TypeOf(@field(EndpointType, decl.name)));
@@ -202,7 +202,14 @@ const TypeGenerator = struct {
                         const t_info = @typeInfo(@field(EndpointType, decl.name));
                         switch (t_info) {
                             .@"struct" => |s| {
-                                const res = try self.parseStruct(decl.name, s);
+                                const res = self.parseStruct(decl.name, s) catch |err| {
+                                    std.log.info(
+                                        "Endpoint: {s} - Type: {s}",
+                                        .{ endpoint_path, decl.name },
+                                    );
+
+                                    return err;
+                                };
                                 try self.setTopLevelType(decl.name, res);
                             },
                             else => {},
@@ -310,7 +317,13 @@ const TypeGenerator = struct {
             const decl_info = @typeInfo(@TypeOf(@field(EndpointType, decl.name)));
             switch (decl_info) {
                 // Find get/post/put/patch/delete functions
-                .@"fn" => try self.populateFnTypescript(decl, decl_info.@"fn", endpoint_path),
+                .@"fn" => self.populateFnTypescript(decl, decl_info.@"fn", endpoint_path) catch |err| {
+                    std.log.info(
+                        "Endpoint: {s} - Type: {s}",
+                        .{ endpoint_path, decl.name },
+                    );
+                    return err;
+                },
                 else => {},
             }
         }
@@ -360,13 +373,10 @@ const TypeGenerator = struct {
     fn parseStruct(self: *Self, struct_name: []const u8, S: Type.Struct) !ParseResult {
         // Find adjacent union ahead of time
         var adjacent_union: ?AdjacentUnion = null;
-        var union_ts: []const u8 = undefined;
         {
             inline for (S.fields) |field| {
                 const info = @typeInfo(field.type);
                 if (info != .@"union") continue;
-
-                union_ts = try self.parseUnion(info.@"union", field.type);
 
                 var union_repr: ?UnionRepr = null;
                 inline for (info.@"union".decls) |decl| {
@@ -434,6 +444,15 @@ const TypeGenerator = struct {
             comptime var T: type = field.type;
             if (comptime startsWith(@typeName(T), "utils.types.JsonArray(")) {
                 T = @FieldType(@FieldType(T, "list"), "items");
+            }
+
+            // Ensure Optionals have default values
+            if (comptime isOptional(field.type) and field.defaultValue() == null) {
+                std.log.info(
+                    "Optional type \"{s}\" must have a provided default value: {s}",
+                    .{ field.name, @typeName(field.type) },
+                );
+                return error.OptionalMissingDefault;
             }
 
             const parse_result = try self.extractIdentifier(T);
@@ -848,6 +867,31 @@ test "Nested Optionals" {
         \\}
         \\}
     );
+}
+
+test "Optionals require default values" {
+    const alloc = std.testing.allocator;
+
+    var arena = ArenaAllocator.init(alloc);
+    defer arena.deinit();
+
+    const Optional = @import("utils/types.zig").Optional;
+
+    const Foo = struct {
+        opt: Optional(bool),
+    };
+
+    var type_generator = try TypeGenerator.init(arena.allocator());
+    defer type_generator.deinit();
+
+    // This should throw an error
+    _ = type_generator.extractIdentifier(Foo) catch |err| {
+        try std.testing.expectEqual(err, error.OptionalMissingDefault);
+        return;
+    };
+
+    // If this is reached, we did not throw an error when expected.
+    try std.testing.expect(false);
 }
 
 test "JsonArray(T)" {

--- a/src/typegen.zig
+++ b/src/typegen.zig
@@ -10,7 +10,9 @@ const Type = std.builtin.Type;
 const EndpointDef = @import("main.zig").EndpointDef;
 const stringToEnum = std.meta.stringToEnum;
 const UnionRepr = @import("middleware/parse-body.zig").UnionRepr;
-const JsonArray = @import("utils/types.zig").JsonArray;
+const types = @import("utils/types.zig");
+const isOptional = types.isOptional;
+const JsonArray = types.JsonArray;
 
 const endpoint_fn_names = [_][]const u8{ "get", "post", "put", "patch", "delete" };
 
@@ -554,16 +556,10 @@ const TypeGenerator = struct {
         var res: ArrayList(u8) = .empty;
 
         // Special case for Optional(T)
-        if (strEqls(shortTypeName(@typeName(T)), "Optional")) {
-            inline for (U.fields) |f| {
-                if (strEqls(f.name, "value")) {
-                    const parsed_res = try self.extractIdentifier(f.type);
-                    try res.appendSlice(self.arena_alloc, parsed_res.parsed);
-
-                    return res.toOwnedSlice(self.arena_alloc);
-                }
-            }
-            return error.InvalidOptionalDeclaration;
+        if (isOptional(T)) {
+            const parsed_res = try self.extractIdentifier(@FieldType(T, "value"));
+            try res.appendSlice(self.arena_alloc, parsed_res.parsed);
+            return res.toOwnedSlice(self.arena_alloc);
         }
 
         var union_repr: ?UnionRepr = null;

--- a/src/utils/types.zig
+++ b/src/utils/types.zig
@@ -202,12 +202,16 @@ pub fn JsonObject(comptime T: type) type {
     const info = @typeInfo(T);
     const S = switch (info) {
         .@"struct" => |S| S,
-        else => @compileError("JsonObject must wrap a struct"),
+        else => @compileError("JsonObject must wrap a struct: " ++ @typeName(T)),
     };
     return struct {
         const Self = @This();
 
         obj: T,
+
+        pub fn init(obj: T) Self {
+            return .{ .obj = obj };
+        }
 
         pub fn jsonStringify(self: *const Self, jws: anytype) !void {
             try jws.beginObject();
@@ -215,13 +219,16 @@ pub fn JsonObject(comptime T: type) type {
                 if (Field.type == void) continue;
 
                 var emit_field: bool = true;
-                if (isOptional(Field.type) and @field(self.obj, Field.name) == .not_provided) {
-                    emit_field = false;
+                if (comptime isOptional(Field.type)) {
+                    if (@field(self.obj, Field.name) == .not_provided) {
+                        emit_field = false;
+                    }
                 }
 
                 if (emit_field) {
                     try jws.objectField(Field.name);
-                    try jws.write(@field(self.obj, Field.name));
+                    const j: Json(Field.type) = .init(@field(self.obj, Field.name));
+                    try jws.write(j);
                 }
             }
             try jws.endObject();
@@ -280,7 +287,8 @@ pub fn JsonArray(comptime T: type) type {
         }
 
         pub fn jsonStringify(self: *const Self, jws: anytype) !void {
-            try json.Stringify.write(jws, self.list.items);
+            const j: JsonSlice(T) = .init(self.list.items);
+            try jws.write(j);
         }
     };
 }
@@ -326,4 +334,103 @@ test "stringify json array" {
     defer alloc.free(str);
 
     try std.testing.expectEqualStrings(str, "{\"data\":[1,2,3]}");
+}
+
+pub fn JsonSlice(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        slice: []const T,
+
+        pub fn init(slice: []const T) Self {
+            return .{ .slice = slice };
+        }
+
+        pub fn jsonStringify(self: *const Self, jws: anytype) !void {
+            try jws.beginArray();
+            for (self.slice) |x| {
+                const j: Json(T) = .init(x);
+                try jws.write(j);
+            }
+            try jws.endArray();
+        }
+    };
+}
+
+pub fn JsonNullable(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        value: ?T,
+
+        pub fn init(value: ?T) Self {
+            return .{ .value = value };
+        }
+
+        pub fn jsonStringify(self: *const Self, jws: anytype) !void {
+            if (self.value) |v| {
+                const j: Json(T) = .init(v);
+                try jws.write(j);
+            } else {
+                try jws.write(null);
+            }
+        }
+    };
+}
+
+pub fn JsonUnion(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        value: T,
+
+        pub fn init(value: T) Self {
+            return .{ .value = value };
+        }
+
+        pub fn jsonStringify(self: *const Self, jws: anytype) !void {
+            switch (self.value) {
+                inline else => |v| {
+                    const j: Json(@TypeOf(v)) = .init(v);
+                    try jws.write(j);
+                },
+            }
+        }
+    };
+}
+
+pub fn JsonPrimitive(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        value: T,
+
+        pub fn init(value: T) Self {
+            return .{ .value = value };
+        }
+
+        pub fn jsonStringify(self: *const Self, jws: anytype) !void {
+            try jws.write(self.value);
+        }
+    };
+}
+
+pub fn Json(comptime T: type) type {
+    const info = @typeInfo(T);
+    switch (info) {
+        .@"struct" => |S| {
+            if (S.decls.len == 0) return JsonObject(T);
+        },
+        .pointer => |p| {
+            if (p.child != u8) return JsonSlice(p.child);
+        },
+        .optional => |O| return JsonNullable(O.child),
+        .@"union" => {
+            if (!isOptional(T)) return JsonUnion(T);
+        },
+        .array => @compileError("array not supported"),
+        .vector => @compileError("vector not supported"),
+        else => {},
+    }
+    return JsonPrimitive(T);
 }

--- a/src/utils/types.zig
+++ b/src/utils/types.zig
@@ -58,7 +58,9 @@ pub fn Optional(comptime T: type) type {
             source: anytype,
             options: json.ParseOptions,
         ) json.ParseError(@TypeOf(source.*))!Self {
-            return .{ .value = try json.innerParse(T, allocator, source, options) };
+            // Supports implicitly parsing `null` to `.not_provided`
+            const value: ?T = try json.innerParse(?T, allocator, source, options);
+            return if (value) |v| .{ .value = v } else .not_provided;
         }
 
         pub fn jsonParseFromValue(
@@ -66,7 +68,9 @@ pub fn Optional(comptime T: type) type {
             source: json.Value,
             options: json.ParseOptions,
         ) json.ParseError(@TypeOf(allocator))!Self {
-            return .{ .value = try json.parseFromValueLeaky(T, allocator, source, options) };
+            // Supports implicitly parsing `null` to `.not_provided`
+            const value: ?T = try json.parseFromValueLeaky(?T, allocator, source, options);
+            return if (value) |v| .{ .value = v } else .not_provided;
         }
 
         pub fn jsonStringify(self: *const Self, jws: anytype) !void {

--- a/src/utils/types.zig
+++ b/src/utils/types.zig
@@ -39,20 +39,9 @@ pub fn Optional(comptime T: type) type {
         }
 
         /// Wraps a value in an Optional.
-        pub fn to(e: anytype) Optional(T) {
-            const E = @TypeOf(e);
-            const info = @typeInfo(E);
-            if (info == .optional) {
-                const inner_type = info.optional.child;
-                if (inner_type != T) {
-                    @compileError("Type mismatch: " ++ @typeName(inner_type) ++ " - " ++ @typeName(T));
-                }
-                if (e) |v| return .{ .value = v };
-                return .not_provided;
-            } else {
-                if (E != T) @compileError("Type mismatch: " ++ @typeName(E) ++ " - " ++ @typeName(T));
-                return .{ .value = e };
-            }
+        pub fn to(value: ?T) Optional(T) {
+            if (value) |v| return .{ .value = v };
+            return .not_provided;
         }
 
         pub fn jsonParse(
@@ -135,6 +124,12 @@ test "Optional.to" {
 
         try std.testing.expect(@TypeOf(got) == ?Foo);
         try std.testing.expect(got.?.foo == 123);
+    }
+
+    {
+        // Support anonymous structs
+        const opt: Optional(Foo) = Optional(Foo).to(.{ .foo = 123 });
+        try std.testing.expectEqual(123, opt.value.foo);
     }
 }
 

--- a/src/utils/types.zig
+++ b/src/utils/types.zig
@@ -107,7 +107,7 @@ pub fn Optional(comptime T: type) type {
                 }
                 return .not_provided;
             }
-            return pg.types.decodeScalar(value.data, oid);
+            return .{ .value = try pg.types.decodeScalar(.safe, Unwrap(T), value.data, oid) };
         }
     };
 }
@@ -136,6 +136,12 @@ test "Optional.to" {
         try std.testing.expect(@TypeOf(got) == ?Foo);
         try std.testing.expect(got.?.foo == 123);
     }
+}
+
+test "Optional.fromPgzRow" {
+    _ = Optional(i32).fromPgzRow(.{ .is_null = false, .data = "123" }, 0) catch {};
+    const o = try Optional(?i32).fromPgzRow(.{ .is_null = true, .data = "" }, 0);
+    try std.testing.expect(o.value == null);
 }
 
 test "parse json Optional" {

--- a/src/utils/types.zig
+++ b/src/utils/types.zig
@@ -455,8 +455,11 @@ pub fn JsonUnion(comptime T: type) type {
         pub fn jsonStringify(self: *const Self, jws: anytype) !void {
             switch (self.value) {
                 inline else => |v| {
-                    const j: Json(@TypeOf(v)) = .init(v);
-                    try jws.write(j);
+                    const V = @TypeOf(v);
+                    if (V != void) {
+                        const j: Json(V) = .init(v);
+                        try jws.write(j);
+                    }
                 },
             }
         }
@@ -489,9 +492,7 @@ pub fn Json(comptime T: type) type {
             if (p.child != u8) return JsonSlice(p.child);
         },
         .optional => |O| return JsonNullable(O.child),
-        .@"union" => {
-            if (!isOptional(T)) return JsonUnion(T);
-        },
+        .@"union" => return JsonUnion(T),
         .array => @compileError("array not supported"),
         .vector => @compileError("vector not supported"),
         else => {},

--- a/src/utils/types.zig
+++ b/src/utils/types.zig
@@ -2,6 +2,8 @@
 const std = @import("std");
 const json = std.json;
 
+const pg = @import("pg");
+
 pub fn Unwrap(T: type) type {
     const info = @typeInfo(T);
     if (info == .optional) return Unwrap(info.optional.child);
@@ -82,6 +84,40 @@ pub fn Optional(comptime T: type) type {
                     // It's the responsibility of the parent struct (JsonObject)
                     // to skip stringifying the optional field.
                     return json.Stringify.Error.WriteFailed;
+                },
+            }
+        }
+
+        pub fn fromPgzRow(
+            data: []const u8,
+            oid: i32,
+        ) !Self {
+            // Note: Unable to access the `is_null` flag of the pg.zig value,
+            // so this is our best option
+            if (data.len == 0) return .not_provided;
+            return getScalar(data, oid);
+        }
+
+        // Note: Copied from pg.zig library. Ideally, the library should be updated to export this function.
+        fn getScalar(data: []const u8, oid: i32) T {
+            switch (T) {
+                u8 => return pg.types.Char.decode(data, oid),
+                i16 => return pg.types.Int16.decode(data, oid),
+                i32 => return pg.types.Int32.decode(data, oid),
+                i64 => return pg.types.Int64.decode(data, oid),
+                f32 => return pg.types.Float32.decode(data, oid),
+                f64 => return pg.types.Float64.decode(data, oid),
+                bool => return pg.types.Bool.decode(data, oid),
+                []const u8 => return pg.types.Bytea.decode(data, oid),
+                []u8 => return @constCast(pg.types.Bytea.decode(data, oid)),
+                pg.types.Numeric => return pg.types.Numeric.decode(data, oid),
+                pg.types.Cidr => return pg.types.Cidr.decode(data, oid),
+                else => switch (@typeInfo(T)) {
+                    .@"enum" => {
+                        const str = pg.types.Bytea.decode(data, oid);
+                        return std.meta.stringToEnum(T, str).?;
+                    },
+                    else => @compileError("cannot get value of type " ++ @typeName(T)),
                 },
             }
         }

--- a/src/utils/types.zig
+++ b/src/utils/types.zig
@@ -18,6 +18,10 @@ pub fn unwrap(T: type, t: T) ?Unwrap(T) {
     return t;
 }
 
+pub fn isOptional(comptime T: type) bool {
+    return @typeInfo(T) == .@"union" and @hasField(T, "value") and @hasField(T, "not_provided");
+}
+
 pub fn Optional(comptime T: type) type {
     return union(enum) {
         not_provided,
@@ -64,10 +68,49 @@ pub fn Optional(comptime T: type) type {
         ) json.ParseError(@TypeOf(allocator))!Self {
             return .{ .value = try json.parseFromValueLeaky(T, allocator, source, options) };
         }
+
+        pub fn jsonStringify(self: *const Self, jws: anytype) !void {
+            switch (self.*) {
+                .value => |v| try json.Stringify.write(jws, v),
+                .not_provided => {
+                    // It's not possible to stringify an optional that's not provided,
+                    // so the only logical action is to error.
+                    // It's the responsibility of the parent struct (JsonObject)
+                    // to skip stringifying the optional field.
+                    return json.Stringify.Error.WriteFailed;
+                },
+            }
+        }
     };
 }
 
-test "Optional" {
+test "Optional.to" {
+    const Foo = struct {
+        foo: i32,
+    };
+
+    {
+        const foo: Foo = .{ .foo = 123 };
+        const opt: Optional(Foo) = .to(foo);
+
+        const got = opt.get();
+
+        try std.testing.expect(@TypeOf(got) == ?Foo);
+        try std.testing.expect(got.?.foo == 123);
+    }
+
+    {
+        const foo: ?Foo = .{ .foo = 123 };
+        const opt: Optional(Foo) = .to(foo);
+
+        const got = opt.get();
+
+        try std.testing.expect(@TypeOf(got) == ?Foo);
+        try std.testing.expect(got.?.foo == 123);
+    }
+}
+
+test "parse json Optional" {
     const Foo = struct {
         foo: Optional(?i32) = .not_provided,
         bar: Optional(?i32) = .not_provided,
@@ -117,6 +160,101 @@ test "Optional" {
     if (foo.bar.value) |_| try std.testing.expect(false);
 }
 
+test "stringify json Optional" {
+    const stringify = @import("json.zig").stringify;
+    const alloc = std.testing.allocator;
+
+    {
+        const opt: Optional(i32) = .{ .value = 1 };
+        const str = try stringify(alloc, opt, .{});
+        defer alloc.free(str);
+        try std.testing.expectEqualStrings(str, "1");
+    }
+
+    {
+        const opt: Optional(i32) = .not_provided;
+        const strOrError = stringify(alloc, opt, .{});
+        try std.testing.expectError(json.Stringify.Error.WriteFailed, strOrError);
+    }
+
+    const Foo = struct {
+        data: Optional(i32),
+    };
+
+    {
+        const foo: Foo = .{
+            .data = .not_provided,
+        };
+        const strOrError = stringify(alloc, foo, .{});
+        try std.testing.expectError(json.Stringify.Error.WriteFailed, strOrError);
+    }
+    {
+        const foo: Foo = .{
+            .data = .{ .value = 123 },
+        };
+        const str = try stringify(alloc, foo, .{});
+        defer alloc.free(str);
+        try std.testing.expectEqualStrings(str, "{\"data\":123}");
+    }
+}
+
+pub fn JsonObject(comptime T: type) type {
+    const info = @typeInfo(T);
+    const S = switch (info) {
+        .@"struct" => |S| S,
+        else => @compileError("JsonObject must wrap a struct"),
+    };
+    return struct {
+        const Self = @This();
+
+        obj: T,
+
+        pub fn jsonStringify(self: *const Self, jws: anytype) !void {
+            try jws.beginObject();
+            inline for (S.fields) |Field| {
+                if (Field.type == void) continue;
+
+                var emit_field: bool = true;
+                if (isOptional(Field.type) and @field(self.obj, Field.name) == .not_provided) {
+                    emit_field = false;
+                }
+
+                if (emit_field) {
+                    try jws.objectField(Field.name);
+                    try jws.write(@field(self.obj, Field.name));
+                }
+            }
+            try jws.endObject();
+        }
+    };
+}
+
+test "stringify JsonObject" {
+    const stringify = @import("json.zig").stringify;
+    const alloc = std.testing.allocator;
+
+    const Foo = JsonObject(struct {
+        data: Optional(i32),
+    });
+
+    {
+        const foo: Foo = .{
+            .obj = .{ .data = .not_provided },
+        };
+        const str = try stringify(alloc, foo, .{});
+        defer alloc.free(str);
+        try std.testing.expectEqualStrings(str, "{}");
+    }
+    {
+        const foo: Foo = .{
+            .obj = .{ .data = .{ .value = 123 } },
+        };
+        const str = try stringify(alloc, foo, .{});
+        defer alloc.free(str);
+        try std.testing.expectEqualStrings(str, "{\"data\":123}");
+    }
+}
+
 pub fn JsonArray(comptime T: type) type {
     return struct {
         const Self = @This();
@@ -145,32 +283,6 @@ pub fn JsonArray(comptime T: type) type {
             try json.Stringify.write(jws, self.list.items);
         }
     };
-}
-
-test "to" {
-    const Foo = struct {
-        foo: i32,
-    };
-
-    {
-        const foo: Foo = .{ .foo = 123 };
-        const opt: Optional(Foo) = .to(foo);
-
-        const got = opt.get();
-
-        try std.testing.expect(@TypeOf(got) == ?Foo);
-        try std.testing.expect(got.?.foo == 123);
-    }
-
-    {
-        const foo: ?Foo = .{ .foo = 123 };
-        const opt: Optional(Foo) = .to(foo);
-
-        const got = opt.get();
-
-        try std.testing.expect(@TypeOf(got) == ?Foo);
-        try std.testing.expect(got.?.foo == 123);
-    }
 }
 
 test "parse json array" {

--- a/src/utils/types.zig
+++ b/src/utils/types.zig
@@ -16,6 +16,18 @@ pub fn unwrap(T: type, t: T) ?Unwrap(T) {
         if (t) |inner| {
             return unwrap(info.optional.child, inner);
         }
+        return null;
+    }
+    return t;
+}
+
+pub fn unwrapPtr(T: type, t: *T) ?*Unwrap(T) {
+    const info = @typeInfo(T);
+    if (info == .optional) {
+        if (t.*) |*inner| {
+            return unwrapPtr(info.optional.child, inner);
+        }
+        return null;
     }
     return t;
 }
@@ -34,8 +46,19 @@ pub fn Optional(comptime T: type) type {
         /// Returns the value if it is present in this Optional, otherwise returns null.
         /// This function will unwrap multiple levels of null, down to the actual value.
         pub fn get(self: Self) ?Unwrap(T) {
-            if (self == .value) return unwrap(T, self.value);
-            return null;
+            return switch (self) {
+                .value => |v| unwrap(T, v),
+                else => null,
+            };
+        }
+
+        /// Returns a pointer to the value if it is present in this Optional, otherwise returns null.
+        /// This function will unwrap multiple levels of null, down to the actual value.
+        pub fn getPtr(self: *Self) ?*Unwrap(T) {
+            return switch (self.*) {
+                .value => |*v| unwrapPtr(T, v),
+                else => null,
+            };
         }
 
         /// Wraps a value in an Optional.
@@ -99,6 +122,18 @@ pub fn Optional(comptime T: type) type {
             return .{ .value = try pg.types.decodeScalar(.safe, Unwrap(T), value.data, oid) };
         }
     };
+}
+
+test "Optional.getPtr" {
+    {
+        var opt: Optional(i32) = .to(123);
+        opt.getPtr().?.* = 456;
+        try std.testing.expectEqual(456, opt.value);
+    }
+    {
+        var opt: Optional(?i32) = .to(null);
+        try std.testing.expectEqual(null, opt.getPtr());
+    }
 }
 
 test "Optional.to" {

--- a/src/zap/endpoint.zig
+++ b/src/zap/endpoint.zig
@@ -14,6 +14,7 @@ const JoltServer = @import("../main.zig").JoltServer;
 
 const sortByStringLengthDesc = @import("../utils/array_utils.zig").sortByStringLengthDesc;
 const stringify = @import("../utils/json.zig").stringify;
+const Json = @import("../utils/types.zig").Json;
 
 pub fn MiddlewareContext(comptime Context: type) type {
     return struct {
@@ -153,7 +154,8 @@ pub const RequestHandler = struct {
                             if (response.content_type == null) {
                                 try req.setHeader("content-type", "application/json");
                             }
-                            break :blk try stringify(alloc, body, response.opts);
+                            const json: Json(ReturnType) = .init(body);
+                            break :blk try stringify(alloc, json, response.opts);
                         },
                     };
                     try req.sendBody(data);

--- a/src/zap/endpoint.zig
+++ b/src/zap/endpoint.zig
@@ -61,7 +61,6 @@ pub fn Response(comptime ReturnType: type) type {
         body: ?ReturnType = null,
         err: ?[]const u8 = null,
         content_type: ?[]const u8 = null,
-        opts: std.json.Stringify.Options = .{},
         status: ?StatusCode = null,
         finished: bool = false, // supports WebSockets
     };
@@ -155,7 +154,7 @@ pub const RequestHandler = struct {
                                 try req.setHeader("content-type", "application/json");
                             }
                             const json: Json(ReturnType) = .init(body);
-                            break :blk try stringify(alloc, json, response.opts);
+                            break :blk try stringify(alloc, json, .{});
                         },
                     };
                     try req.sendBody(data);


### PR DESCRIPTION
Prevent `emit` flags from being accessible to set from response, and enforce usage of `Optional` type in GET responses.