### PR TITLE
Query param union parsing

### DIFF
--- a/src/middleware/parse-query-params.zig
+++ b/src/middleware/parse-query-params.zig
@@ -56,7 +56,7 @@ pub fn parseQueryParams(comptime Context: type) MiddlewareFn(Context) {
             comptime FieldType: type,
             alloc: Allocator,
             param: []const u8,
-        ) !Optional(FieldType) {
+        ) Optional(FieldType) {
             const info = @typeInfo(FieldType);
             switch (info) {
                 .bool => {
@@ -96,7 +96,7 @@ pub fn parseQueryParams(comptime Context: type) MiddlewareFn(Context) {
                     if (std.meta.stringToEnum(FieldType, param)) |v| {
                         return .{ .value = v };
                     } else {
-                        return error.InvalidEnumVariant;
+                        return .not_provided;
                     }
                 },
                 .@"struct", .@"union" => {
@@ -107,18 +107,25 @@ pub fn parseQueryParams(comptime Context: type) MiddlewareFn(Context) {
                         };
                         return .{ .value = parsed };
                     }
-                    const parsed: std.json.Parsed(FieldType) = std.json.parseFromSlice(FieldType, alloc, param, .{}) catch {
-                        std.log.err("query param failed to parse as json: {s} - {s}", .{ @typeName(FieldType), param });
-                        return .not_provided;
-                    };
-                    return .{ .value = parsed.value };
+                    if (info == .@"struct") @compileError("Must define paramParse for struct: " ++ @typeName(FieldType));
+                    // Note: `untagged` union parsing
+                    inline for (@typeInfo(FieldType).@"union".fields) |f| {
+                        if (f.type == void) {
+                            if (std.mem.eql(u8, f.name, param)) {
+                                return .{ .value = @unionInit(FieldType, f.name, {}) };
+                            }
+                        } else if (_handleQueryParam(f.type, alloc, param).get()) |v| {
+                            return .{ .value = @unionInit(FieldType, f.name, v) };
+                        }
+                    }
+                    return .not_provided;
                 },
                 .optional => {
                     if (std.mem.eql(u8, param, "null")) {
                         return .{ .value = null };
                     } else {
                         // Optional(T) -> Optional(?T)
-                        switch (try _handleQueryParam(info.optional.child, alloc, param)) {
+                        switch (_handleQueryParam(info.optional.child, alloc, param)) {
                             .value => |v| {
                                 // Implicit conversion: ?T -> T
                                 return .{ .value = v };
@@ -186,7 +193,7 @@ pub fn parseQueryParams(comptime Context: type) MiddlewareFn(Context) {
             if (param_opt) |param| {
                 const is_optional = comptime isOptional(field.type);
                 const T = if (is_optional) field.type.childType() else field.type;
-                switch (try _handleQueryParam(T, alloc, param.items)) {
+                switch (_handleQueryParam(T, alloc, param.items)) {
                     .value => |v| {
                         @field(@field(ctx, query_params), field.name) = if (is_optional) .to(v) else v;
                         return false;

--- a/src/middleware/parse-query-params.zig
+++ b/src/middleware/parse-query-params.zig
@@ -100,11 +100,17 @@ pub fn parseQueryParams(comptime Context: type) MiddlewareFn(Context) {
                     }
                 },
                 .@"struct", .@"union" => {
-                    const parsed = std.json.parseFromSlice(FieldType, alloc, param, .{}) catch {
-                        std.log.info("parse union failed: {s} - {s}", .{ @typeName(FieldType), param });
+                    if (std.meta.hasFn(FieldType, "paramParse")) {
+                        const parsed: FieldType = FieldType.paramParse(alloc, param) catch {
+                            std.log.err("query param failed to parse as custom: {s} - {s}", .{ @typeName(FieldType), param });
+                            return .not_provided;
+                        };
+                        return .{ .value = parsed };
+                    }
+                    const parsed: std.json.Parsed(FieldType) = std.json.parseFromSlice(FieldType, alloc, param, .{}) catch {
+                        std.log.err("query param failed to parse as json: {s} - {s}", .{ @typeName(FieldType), param });
                         return .not_provided;
                     };
-                    errdefer parsed.deinit();
                     return .{ .value = parsed.value };
                 },
                 .optional => {

--- a/src/typegen.zig
+++ b/src/typegen.zig
@@ -662,8 +662,12 @@ const TypeGenerator = struct {
                         } else {
                             try res.appendSlice(self.arena_alloc, " | ");
                         }
-                        const ident = (try self.extractIdentifier(field.type)).parsed;
-                        try res.appendSlice(self.arena_alloc, ident);
+                        if (@typeInfo(field.type) == .void) {
+                            try res.print(self.arena_alloc, "\"{s}\"", .{field.name});
+                        } else {
+                            const ident = (try self.extractIdentifier(field.type)).parsed;
+                            try res.appendSlice(self.arena_alloc, ident);
+                        }
                     }
                 },
             }


### PR DESCRIPTION
Add `paramParse` support to allow structs and unions to define custom query param parsing logic.